### PR TITLE
OCap style guide, lint tool for .py

### DIFF
--- a/style-guide/ocap-py-style-guide.md
+++ b/style-guide/ocap-py-style-guide.md
@@ -1,0 +1,305 @@
+# OCap Python Style Guide
+
+This guide is for Python programmers who want code that supports powerful patterns of cooperation without vulnerability.
+
+If code is good, we will want to reuse it, and that usually means we will want to test it. Code that reaches out to the world directly is harder to test, so this guide recommends injecting I/O explicitly, including filesystem, network, clock, environment, subprocess, and console access.
+
+## Separate Definition from Execution
+
+Move logic into `main(...)` or `run(...)` and keep the script entrypoint thin.
+
+Bad:
+
+```py
+import os
+
+file_name = os.environ["INPUT_FILE"]
+with open(file_name) as fp:
+    print(len(fp.readlines()))
+```
+
+Good:
+
+```py
+import os
+
+
+def main():
+    file_name = os.environ["INPUT_FILE"]
+    with open(file_name) as fp:
+        print(len(fp.readlines()))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Pass I/O In Explicitly
+
+Do not let deep helper functions reach out to the environment or other I/O directly. Pass in the specific inputs they need.
+
+Bad:
+
+```py
+import os
+
+
+def api_url():
+    return os.environ.get("API_URL", "http://127.0.0.1:23119")
+```
+
+Good:
+
+```py
+def api_url(environ):
+    return environ.get("API_URL", "http://127.0.0.1:23119")
+
+
+if __name__ == "__main__":
+    import os
+
+    print(api_url(os.environ))
+```
+
+TODO: find a more plausible Python example for this section. The `api_url(environ)` example makes the dependency explicit, but it is still more mechanical than idiomatic.
+
+## Prefer Small Capability Parameters
+
+Pass only the authority a function needs, not a grab bag of unrelated globals.
+
+Bad:
+
+```py
+def sync_everything(config):
+    with open(config["path"]) as fp:
+        data = fp.read()
+    now = config["clock"]()
+    config["logger"].info("synced at %s", now)
+```
+
+Good:
+
+```py
+def sync_file(path, open_text, now, log):
+    with open_text(path) as fp:
+        data = fp.read()
+    log.info("synced at %s", now())
+```
+
+## Keep Pure Logic Pure
+
+Parsing, filtering, formatting, and data transformation should not perform I/O.
+
+Bad:
+
+```py
+from datetime import datetime, timedelta
+
+
+def recent_pdfs(scan_dir):
+    cutoff = datetime.now() - timedelta(hours=1)
+    return [
+        path for path in scan_dir.iterdir()
+        if path.suffix == ".pdf" and path.stat().st_mtime >= cutoff.timestamp()
+    ]
+```
+
+Good:
+
+```py
+def is_recent_pdf(name, modified_at, cutoff):
+    return name.endswith(".pdf") and modified_at >= cutoff
+
+
+def recent_pdfs(entries, cutoff):
+    return [entry for entry in entries if is_recent_pdf(entry.name, entry.modified_at, cutoff)]
+```
+
+## Replace Module Globals with Configuration Data
+
+Avoid module-level configuration derived from environment, home directory, or current process state.
+
+Bad:
+
+```py
+import os
+from pathlib import Path
+
+API_URL = os.environ.get("API_URL", "http://127.0.0.1:23119")
+SCAN_DIR = Path.home() / "Documents" / "scan-from-mobile"
+```
+
+Good:
+
+```py
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Config:
+    api_url: str
+    scan_dir: str
+
+
+def load_config(environ, home):
+    return Config(
+        api_url=environ.get("API_URL", "http://127.0.0.1:23119"),
+        scan_dir=str(home / "Documents" / "scan-from-mobile"),
+    )
+```
+
+## Inject Time, Network, and Subprocess Power
+
+Clock, HTTP, and subprocess access are capabilities. Treat them that way.
+
+Bad:
+
+```py
+from datetime import datetime
+import subprocess
+import urllib.request
+
+
+def refresh(url, src, dst):
+    stamp = datetime.now().isoformat()
+    urllib.request.urlopen(url)
+    subprocess.run(["ocrmypdf", src, dst], check=True)
+    return stamp
+```
+
+Good:
+
+```py
+def refresh(url, src, dst, now, http_get, run_ocr):
+    stamp = now().isoformat()
+    http_get(url)
+    run_ocr(src, dst)
+    return stamp
+```
+
+## Prefer a Tiny Authority-Bearing Shell
+
+Library code should expose a reusable callable such as `run(...)`. The `__main__` block should just wire real authorities.
+
+Good:
+
+```py
+def run(config, now, http, ocr, reporter):
+    ...
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+    from datetime import datetime
+
+    run(
+        config=load_config(os.environ, home_dir()),
+        now=datetime.now,
+        http=urllib_http_client(),
+        ocr=ocrmypdf_runner(),
+        reporter=console_reporter(sys.stdout, sys.stderr),
+    )
+```
+
+## What This Refactor Taught
+
+A useful way to refactor toward OCap discipline is to play "hunt the red squiggly."
+If removing an ambient import such as `os`, `sys`, `urllib.request`, or `subprocess`
+breaks a helper, the resulting error points at hidden authority that should probably
+be passed in explicitly.
+
+A few concrete lessons:
+
+- Acquire authority only at the outer script boundary, such as `if __name__ == "__main__":`.
+- Pass authority inward explicitly through arguments.
+- Keep helpers honest about the least authority they need.
+- Keep data separate from authority-bearing objects.
+- Do not smuggle broad authority inside a narrowed object.
+
+### Least Authority First
+
+When refactoring a helper, ask what authority it actually needs, not which module names it currently uses.
+
+For example, a helper like `ensure_ocr_pdf(...)` may appear to need `sys`, `subprocess`, and broad filesystem access.
+But the least authority may be closer to:
+
+- read access to the source path
+- write access to the destination directory
+- an `ocrmypdf` runner capability
+- a diagnostic output stream
+
+That is a better guide than mechanically passing whole modules around.
+
+### Data Is Not Authority
+
+One recurring bug pattern is turning plain data into authority in the middle of the program.
+Examples include:
+
+- path string to `Path(...)` or `open(...)`
+- URL string to `urlopen(...)`
+- command name such as `"ocrmypdf"` to `subprocess.run(...)`
+
+That kind of step should happen only at a deliberate boundary.
+A useful analogy is that turning `"abc"` into `open("abc")` is a little like casting an integer to a pointer.
+The string is data. The opened file is authority.
+
+### Rooted Capability Objects
+
+Sometimes the right move is to introduce a rooted capability object that behaves a bit like `Path`.
+For network access, a rooted URL endpoint can be narrower than passing a general HTTP client.
+
+But a rooted object must not expose the broader authority it was built from.
+If a `UrlEndpoint` stores a public `urlopen` field, then any holder of the endpoint can recover broad network authority.
+That violates POLA even if the object also supports nice rooted operations such as `endpoint / "api" / "users"`.
+
+A better pattern is:
+
+- inject the broad opener at the boundary
+- store it privately inside the rooted object
+- expose only rooted operations such as `/` and `open()`
+
+### Keep Boundary Policy Visible
+
+Defaults such as API roots, desktop directory names, and project-specific subdirectory names are policy.
+They should be visible near the top of the file as data, rather than hidden in the guts of `main(...)`.
+But policy defaults are still different from authority and should not be confused with capability objects.
+
+## Review Checklist
+
+When reviewing Python for OCap discipline, look for:
+
+- `os.environ` used outside startup wiring
+- `Path.home()` or cwd lookups outside startup wiring
+- `datetime.now()` inside selection or transformation logic
+- `urllib`, `requests`, or similar network calls in helpers that could accept an injected client
+- `subprocess.run()` hidden in business logic
+- `print()` or `sys.stderr.write()` scattered through library code
+- module globals initialized from ambient state
+
+## Worked Example Candidates
+
+Scripts like `tools/zotero_link_recent.py` are useful examples because they often combine:
+
+- environment-driven configuration
+- filesystem traversal
+- wall-clock time
+- HTTP calls
+- subprocess execution
+- console reporting
+
+These are good refactoring targets because the behavior is small while the authority surface is easy to inspect.
+
+## TODO
+
+- show the testing benefit directly in the `env(...)` example
+- use a defensive copy of `environ` at the boundary
+- show similar treatment for `sys`
+- show similar treatment for `uuid`
+- show similar treatment for `urllib.request`
+- show similar treatment for `Path`
+- add a section on pathnames as data becoming filesystem authority, including when `Path(...)`, `open(...)`, or related APIs are appropriate boundaries
+- add a section on URLs as data becoming network authority, including when request construction should be confined to the boundary
+- add a section on command names as data becoming process-execution authority, including helpers like `ensure_ocr_pdf()` that should receive an `ocrmypdf` capability instead of calling `subprocess.run(...)` directly
+- explain why turning a piece of data such as `"ocrmypdf"` into authority with `subprocess.run(...)` is a bad pattern, analogous to turning `"abc"` into `open("abc")` or casting an integer to a pointer
+- add a POLA note for rooted network/path-like capability objects: do not expose the underlying opener or other broad authority as a public field, because any holder of the narrowed object could recover access to the wider authority

--- a/style-guide/ocap-py-style-guide.md
+++ b/style-guide/ocap-py-style-guide.md
@@ -265,6 +265,39 @@ Defaults such as API roots, desktop directory names, and project-specific subdir
 They should be visible near the top of the file as data, rather than hidden in the guts of `main(...)`.
 But policy defaults are still different from authority and should not be confused with capability objects.
 
+## Boundary Convention
+
+A useful convention is to separate the script-only authority boundary from the importable program logic.
+
+Use a tiny helper inside:
+
+```py
+if __name__ == "__main__":
+    def _script_io():
+        ...
+    _script_io()
+```
+
+The point of `_script_io()` is to wire authority, not to hide arbitrary program logic.
+
+A practical convention:
+
+- pass existing APIs across the `_script_io()` to `main(...)` boundary rather than wrapping everything immediately
+- for example, pass `datetime.now`, `uuid4`, `subprocess.run`, or `urlopen`
+- then narrow those capabilities inside `main(...)` as needed
+- prefer not to do avoidable observations in `_script_io()` itself
+- for example, pass `datetime.now` rather than calling `datetime.now()` there
+
+One pragmatic exception is that `home` and `cwd` can be treated as platform-provided context for `main(...)`.
+That is, it is reasonable for `_script_io()` to pass `Path.home()` and `Path.cwd()` into `main(...)`.
+
+Rule for allowed ambient scope:
+
+- ambient authority is allowed only in functions defined under `if __name__ == "__main__":`
+- and only when those functions are not called from outside that guarded block
+
+This keeps the ambient boundary explicit and prevents helper functions elsewhere in the module from quietly becoming script-only escape hatches.
+
 ## Review Checklist
 
 When reviewing Python for OCap discipline, look for:
@@ -303,3 +336,4 @@ These are good refactoring targets because the behavior is small while the autho
 - add a section on command names as data becoming process-execution authority, including helpers like `ensure_ocr_pdf()` that should receive an `ocrmypdf` capability instead of calling `subprocess.run(...)` directly
 - explain why turning a piece of data such as `"ocrmypdf"` into authority with `subprocess.run(...)` is a bad pattern, analogous to turning `"abc"` into `open("abc")` or casting an integer to a pointer
 - add a POLA note for rooted network/path-like capability objects: do not expose the underlying opener or other broad authority as a public field, because any holder of the narrowed object could recover access to the wider authority
+- add a note on the slogan "do not prohibit what you cannot enforce": if a path is meant to represent downward-only traversal or read-only access, that should be enforced by the type or wrapper rather than assumed by convention

--- a/style-guide/ocap-py-style-guide.md
+++ b/style-guide/ocap-py-style-guide.md
@@ -7,6 +7,7 @@ If code is good, we will want to reuse it, and that usually means we will want t
 ## Separate Definition from Execution
 
 Move logic into `main(...)` or `run(...)` and keep the script entrypoint thin.
+The script entrypoint is where ambient authority from the Python runtime becomes available.
 
 Bad:
 
@@ -34,6 +35,10 @@ if __name__ == "__main__":
     main()
 ```
 
+This is only the first step.
+It avoids work at import time, but it does not yet make authority flow explicit.
+The next section addresses that.
+
 ## Pass I/O In Explicitly
 
 Do not let deep helper functions reach out to the environment or other I/O directly. Pass in the specific inputs they need.
@@ -51,17 +56,29 @@ def api_url():
 Good:
 
 ```py
-def api_url(environ):
-    return environ.get("API_URL", "http://127.0.0.1:23119")
+def main(file_name, read_text, stdout):
+    lines = read_text(file_name).splitlines()
+    print(len(lines), file=stdout)
 
 
 if __name__ == "__main__":
     import os
+    import sys
 
-    print(api_url(os.environ))
+    def read_text(path):
+        with open(path) as fp:
+            return fp.read()
+
+    main(
+        file_name=os.environ["INPUT_FILE"],
+        read_text=read_text,
+        stdout=sys.stdout,
+    )
 ```
 
-TODO: find a more plausible Python example for this section. The `api_url(environ)` example makes the dependency explicit, but it is still more mechanical than idiomatic.
+This version makes the filesystem and console dependencies explicit.
+
+FIXME: both examples in this section are still toy-like. Replace them with a realistic CLI or filesystem example when available.
 
 ## Prefer Small Capability Parameters
 
@@ -85,6 +102,14 @@ def sync_file(path, open_text, now, log):
         data = fp.read()
     log.info("synced at %s", now())
 ```
+
+In small scripts, the first boundary function may still take a slightly broader bundle such as
+`argv`, `cwd`, `home`, and `stdout`. That is acceptable when it is clearly the script boundary and
+the function promptly breaks that authority down for narrower helpers.
+
+The reviewability risk is that a large `main(...)` makes it hard to see which of those authorities
+are actually used where. If `main(...)` grows large enough that a reviewer must inspect every line
+to verify authority use, it is time to refactor.
 
 ## Keep Pure Logic Pure
 
@@ -148,6 +173,11 @@ def load_config(environ, home):
     )
 ```
 
+When argument defaults depend on capabilities such as `home` or `cwd`, it can still be appropriate
+to resolve those defaults in `parse_args(argv, *, cwd, home)` rather than in `script_entry()`.
+That keeps path-rooting policy close to the CLI interface. The key point is that `parse_args(...)`
+must receive the relevant capabilities explicitly rather than reaching for them ambiently.
+
 ## Inject Time, Network, and Subprocess Power
 
 Clock, HTTP, and subprocess access are capabilities. Treat them that way.
@@ -202,6 +232,35 @@ if __name__ == "__main__":
     )
 ```
 
+For CLI scripts, a useful convention is to name the boundary function `script_entry()`.
+Import ambient modules such as `sys`, `pathlib.Path`, `os`, `subprocess`, or network clients
+inside `script_entry()` and pass the resulting capabilities inward.
+
+For example:
+
+```py
+from pathlib import Path as Path_T
+
+
+def main(argv, *, cwd: Path_T, home: Path_T, stdout):
+    ...
+
+
+if __name__ == "__main__":
+    def script_entry():
+        from pathlib import Path
+        from sys import argv as sys_argv
+        from sys import stdout
+
+        cwd = Path(".")
+        home = Path.home()
+        return main(sys_argv[1:], cwd=cwd, home=home, stdout=stdout)
+
+    raise SystemExit(script_entry())
+```
+
+FIXME: "tiny shell" is directionally right, but "tiny" should not become dogma. A script boundary can be slightly larger when that makes authority flow clearer. The real goal is reviewable authority decomposition, not golfing the entrypoint.
+
 ## What This Refactor Taught
 
 A useful way to refactor toward OCap discipline is to play "hunt the red squiggly."
@@ -216,6 +275,8 @@ A few concrete lessons:
 - Keep helpers honest about the least authority they need.
 - Keep data separate from authority-bearing objects.
 - Do not smuggle broad authority inside a narrowed object.
+
+FIXME: "hunt the red squiggly" is memorable, but also a bit cute. It should not be the main explanation. The stronger statement is that removing ambient imports is a practical audit technique for finding hidden authority.
 
 ### Least Authority First
 
@@ -244,6 +305,20 @@ That kind of step should happen only at a deliberate boundary.
 A useful analogy is that turning `"abc"` into `open("abc")` is a little like casting an integer to a pointer.
 The string is data. The opened file is authority.
 
+The same issue arises with `Path(...)`.
+Using `Path` in a type annotation is fine.
+Using `Path(...)` as an expression turns path data into a filesystem authority-bearing object.
+That step belongs at a deliberate boundary such as `script_entry()` or another clearly marked script I/O function.
+
+For command-line parsing, this means:
+
+- bad: `argparse` returns `Path(...)` values by reaching for ambient `Path` or ambient `cwd`
+- better: `parse_args(argv, *, cwd, home)` receives rooted capabilities and returns `Path` values derived from them
+- also acceptable: `parse_args(...)` returns strings and a later boundary function turns them into rooted `Path` values
+
+The important part is not which of those two acceptable patterns you choose.
+The important part is that the data-to-authority step is reviewable and capability-rooted.
+
 ### Rooted Capability Objects
 
 Sometimes the right move is to introduce a rooted capability object that behaves a bit like `Path`.
@@ -258,6 +333,29 @@ A better pattern is:
 - inject the broad opener at the boundary
 - store it privately inside the rooted object
 - expose only rooted operations such as `/` and `open()`
+
+FIXME: this section may overfit custom wrapper objects. In many Python scripts, a plain rooted `Path` derived from an injected root capability is sufficient, and a bespoke wrapper would add noise rather than clarity.
+
+## Keep Boundary Functions Reviewable
+
+An OCap script can still become hard to audit if the boundary function grows into a long mixed
+orchestration block.
+
+Warning signs:
+
+- `main(...)` both parses arguments and walks the filesystem and performs verification and formats output
+- a reviewer cannot tell at a glance where `cwd`, `home`, or other capabilities are consumed
+- one comprehension mixes path derivation, file reads, parsing, and object construction
+
+Prefer to split such code into helpers that make authority use obvious:
+
+- `parse_args(argv, *, cwd, home)`
+- `iter_verification_items(...)`
+- `build_mounted_media_index(...)`
+- `emit_report(...)`
+
+This is not only about aesthetics.
+Smaller boundary-adjacent helpers make it easier to confirm that a capability is used only for the narrow purpose intended.
 
 ### Keep Boundary Policy Visible
 

--- a/tools/ambient_authority_check.py
+++ b/tools/ambient_authority_check.py
@@ -29,6 +29,9 @@ Current limits:
 - It does not do full name-resolution or alias tracking.
 - It assumes that functions defined under the `__main__` guard are the only
   allowed ambient boundary.
+- TODO: refactor this checker itself to follow the same boundary discipline it
+  critiques; it still relies on non-boundary `Path(...)`, `sys.stderr`, and
+  ambient `print(...)` in its own entry path.
 - It does not yet understand all capability-safe patterns.
 - It still has rough edges around constructors such as `Path(...)` and `open(...)`.
 - It does not prove the absence of ambient authority; it only reports a useful
@@ -111,16 +114,37 @@ class ScriptBoundaryCollector(ast.NodeVisitor):
 
 
 class AmbientAuthorityVisitor(ast.NodeVisitor):
-    def __init__(self, source_lines: list[str], exempt_boundary_funcs: set[str]) -> None:
+    def __init__(
+        self,
+        source_lines: list[str],
+        exempt_boundary_funcs: set[str],
+        parent_links: dict[int, tuple[ast.AST, str | None]],
+    ) -> None:
         self.findings: list[Finding] = []
         self.scope_depth = 0
         self.source_lines = source_lines
         self.boundary_depth = 0
         self.exempt_boundary_funcs = exempt_boundary_funcs
+        self.parent_links = parent_links
 
     def add(self, node: ast.AST, kind: str, detail: str) -> None:
         source = self.source_lines[node.lineno - 1].rstrip("\n")
         self.findings.append(Finding(node.lineno, kind, detail, source))
+
+    def parent_link(self, node: ast.AST) -> tuple[ast.AST, str | None] | None:
+        return self.parent_links.get(id(node))
+
+    def in_annotation_context(self, node: ast.AST) -> bool:
+        cur: ast.AST | None = node
+        while cur is not None:
+            link = self.parent_link(cur)
+            if link is None:
+                return False
+            parent, field = link
+            if field in {"annotation", "returns"}:
+                return True
+            cur = parent
+        return False
 
     def visit_If(self, node: ast.If) -> None:
         is_boundary = is_main_guard(node)
@@ -182,13 +206,55 @@ class AmbientAuthorityVisitor(ast.NodeVisitor):
             self.add(node, "ambient-stdio", name)
         self.generic_visit(node)
 
+    def visit_Name(self, node: ast.Name) -> None:
+        if node.id != "Path" or not isinstance(node.ctx, ast.Load):
+            self.generic_visit(node)
+            return
+
+        if self.in_annotation_context(node):
+            self.generic_visit(node)
+            return
+
+        link = self.parent_link(node)
+        if link is None:
+            self.add(node, "data-to-authority", "Path")
+            self.generic_visit(node)
+            return
+
+        parent, field = link
+        if isinstance(parent, ast.Call) and field == "func":
+            self.generic_visit(node)
+            return
+        if isinstance(parent, ast.Attribute) and field == "value":
+            self.generic_visit(node)
+            return
+
+        self.add(node, "data-to-authority", "Path")
+        self.generic_visit(node)
+
+
+def build_parent_links(tree: ast.AST) -> dict[int, tuple[ast.AST, str | None]]:
+    parent_links: dict[int, tuple[ast.AST, str | None]] = {}
+    for parent in ast.walk(tree):
+        for field, value in ast.iter_fields(parent):
+            if isinstance(value, ast.AST):
+                parent_links[id(value)] = (parent, field)
+            elif isinstance(value, list):
+                for child in value:
+                    if isinstance(child, ast.AST):
+                        parent_links[id(child)] = (parent, field)
+    return parent_links
+
 
 def check_source(source: str) -> list[Finding]:
     tree = ast.parse(source)
     boundaries = ScriptBoundaryCollector()
     boundaries.visit(tree)
+    parent_links = build_parent_links(tree)
     visitor = AmbientAuthorityVisitor(
-        source.splitlines(), boundaries.exempt_boundary_functions()
+        source.splitlines(),
+        boundaries.exempt_boundary_functions(),
+        parent_links,
     )
     visitor.visit(tree)
     return sorted(visitor.findings, key=lambda f: (f.line, f.kind, f.detail))

--- a/tools/ambient_authority_check.py
+++ b/tools/ambient_authority_check.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Report likely ambient-authority uses in a Python source file.
+
+This is a focused checker for issue #55 style refactors, not a general
+security analyzer. It looks for common ambient entry points such as env,
+clock, network, subprocess, and stdio.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    line: int
+    kind: str
+    detail: str
+    source: str
+
+
+def dotted_name(node: ast.AST) -> str | None:
+    parts: list[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def is_main_guard(node: ast.If) -> bool:
+    test = node.test
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.Eq)
+        and len(test.comparators) == 1
+        and isinstance(test.comparators[0], ast.Constant)
+        and test.comparators[0].value == "__main__"
+    )
+
+
+class ScriptBoundaryCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.boundary_depth = 0
+        self.boundary_defs: set[str] = set()
+        self.calls_outside_boundary: set[str] = set()
+
+    def visit_If(self, node: ast.If) -> None:
+        is_boundary = is_main_guard(node)
+        if is_boundary:
+            self.boundary_depth += 1
+        self.generic_visit(node)
+        if is_boundary:
+            self.boundary_depth -= 1
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self.boundary_depth > 0:
+            self.boundary_defs.add(node.name)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if self.boundary_depth > 0:
+            self.boundary_defs.add(node.name)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self.boundary_depth == 0 and isinstance(node.func, ast.Name):
+            self.calls_outside_boundary.add(node.func.id)
+        self.generic_visit(node)
+
+    def exempt_boundary_functions(self) -> set[str]:
+        return self.boundary_defs - self.calls_outside_boundary
+
+
+class AmbientAuthorityVisitor(ast.NodeVisitor):
+    def __init__(self, source_lines: list[str], exempt_boundary_funcs: set[str]) -> None:
+        self.findings: list[Finding] = []
+        self.scope_depth = 0
+        self.source_lines = source_lines
+        self.boundary_depth = 0
+        self.exempt_boundary_funcs = exempt_boundary_funcs
+
+    def add(self, node: ast.AST, kind: str, detail: str) -> None:
+        source = self.source_lines[node.lineno - 1].rstrip("\n")
+        self.findings.append(Finding(node.lineno, kind, detail, source))
+
+    def visit_If(self, node: ast.If) -> None:
+        is_boundary = is_main_guard(node)
+        if is_boundary:
+            self.boundary_depth += 1
+        self.generic_visit(node)
+        if is_boundary:
+            self.boundary_depth -= 1
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self.boundary_depth > 0 and node.name in self.exempt_boundary_funcs:
+            return
+        self.scope_depth += 1
+        self.generic_visit(node)
+        self.scope_depth -= 1
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if self.boundary_depth > 0 and node.name in self.exempt_boundary_funcs:
+            return
+        self.scope_depth += 1
+        self.generic_visit(node)
+        self.scope_depth -= 1
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope_depth += 1
+        self.generic_visit(node)
+        self.scope_depth -= 1
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name = dotted_name(node.func)
+        if name == "datetime.now":
+            self.add(node, "ambient-clock", name)
+        elif name == "Path.home":
+            self.add(node, "ambient-filesystem-root", name)
+        elif name == "Path.cwd":
+            self.add(node, "ambient-filesystem-root", name)
+        elif name == "urllib.request.urlopen":
+            self.add(node, "ambient-network", name)
+        elif name == "subprocess.run":
+            self.add(node, "ambient-subprocess", name)
+        elif name == "uuid.uuid4":
+            self.add(node, "ambient-entropy", name)
+        elif name == "print":
+            if not any(kw.arg == "file" for kw in node.keywords):
+                self.add(node, "ambient-stdio", "print")
+        elif name in {"open", "Path"}:
+            self.add(node, "data-to-authority", name)
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        name = dotted_name(node)
+        if name == "os.environ":
+            self.add(node, "ambient-env", name)
+        elif name in {"sys.stdout", "sys.stderr"}:
+            self.add(node, "ambient-stdio", name)
+        self.generic_visit(node)
+
+
+def check_source(source: str) -> list[Finding]:
+    tree = ast.parse(source)
+    boundaries = ScriptBoundaryCollector()
+    boundaries.visit(tree)
+    visitor = AmbientAuthorityVisitor(
+        source.splitlines(), boundaries.exempt_boundary_functions()
+    )
+    visitor.visit(tree)
+    return sorted(visitor.findings, key=lambda f: (f.line, f.kind, f.detail))
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} PATH", file=sys.stderr)
+        return 2
+
+    source_path = Path(argv[1])
+    findings = check_source(source_path.read_text())
+    for finding in findings:
+        print(f"{source_path}:{finding.line}: {finding.kind}: {finding.detail}")
+        print(f"  {finding.source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/ambient_authority_check.py
+++ b/tools/ambient_authority_check.py
@@ -4,6 +4,35 @@
 This is a focused checker for issue #55 style refactors, not a general
 security analyzer. It looks for common ambient entry points such as env,
 clock, network, subprocess, and stdio.
+
+Architecture:
+
+- Parse the source once with `ast`.
+- Run a prepass that finds functions defined under
+  `if __name__ == "__main__":`.
+- Exempt only those guarded functions that are not called from outside the
+  guarded block.
+- Visit the tree again and report direct ambient entry points such as
+  `os.environ`, `datetime.now()`, `urllib.request.urlopen(...)`,
+  `subprocess.run(...)`, `uuid.uuid4()`, and bare `print(...)`.
+- Include the source line for each finding.
+
+Intended use:
+
+- act as a critic for LLM-assisted OCap refactors
+- provide "red squigglies" for common ambient-authority mistakes
+- complement, not replace, the Python OCap style guide and human review
+
+Current limits:
+
+- It is intentionally syntactic and shallow.
+- It does not do full name-resolution or alias tracking.
+- It assumes that functions defined under the `__main__` guard are the only
+  allowed ambient boundary.
+- It does not yet understand all capability-safe patterns.
+- It still has rough edges around constructors such as `Path(...)` and `open(...)`.
+- It does not prove the absence of ambient authority; it only reports a useful
+  subset of likely violations.
 """
 
 from __future__ import annotations
@@ -138,6 +167,10 @@ class AmbientAuthorityVisitor(ast.NodeVisitor):
             if not any(kw.arg == "file" for kw in node.keywords):
                 self.add(node, "ambient-stdio", "print")
         elif name in {"open", "Path"}:
+            # TODO: fold this back into the ambient-authority rules.
+            # Using already-held authority such as cwd / "file" is fine;
+            # the real problem is ambient constructors like Path("file") or
+            # open("file").
             self.add(node, "data-to-authority", name)
         self.generic_visit(node)
 


### PR DESCRIPTION
refs:
 - #55 

see also:
 - [DisciplinedPython](https://github.com/dckc/awesome-ocap/wiki/DisciplinedPython)